### PR TITLE
Support for 16KB page sizes for native lib (Android 15 support)

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,5 +1,6 @@
 # APP_ABI := all
 APP_ABI := armeabi-v7a x86 x86_64 arm64-v8a
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true
 
 # Explicit setting ref:
 # - https://developer.android.com/ndk/guides/stable_apis


### PR DESCRIPTION
Adding support for 16KB page size for native lib.

Android 15's coming with a breaking change. Here's the documentation mentioning it
https://developer.android.com/guide/practices/page-sizes#ndk-build_1

I am using cordova-sqlite-storage plugin and there's already a issue created: https://github.com/storesafe/cordova-sqlite-storage/issues/1021

So I made a change to Application.mk which should be build using NDK 27 or above.
Tested it by re-building the project, generated the jar. And verified it by launching the app in Android 15 Emulator (arm64) and app works.

@brodycj If you could take a look at this PR and provide next steps for using the native libs for the plugin, That would be so helpful.


Thanks in advance.